### PR TITLE
Removes not used json library

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint-plugin-prettier": "3.1.4",
     "jest": "23.6.0",
     "jsdom": "16.4.0",
-    "json": "9.0.6",
     "live-server": "1.2.1",
     "mversion": "2.0.0",
     "node-sass": "4.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5246,11 +5246,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json@9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/json/-/json-9.0.6.tgz#7972c2a5a48a42678db2730c7c2c4ee6e4e24585"
-  integrity sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=
-
 jsonfile@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"


### PR DESCRIPTION
I noticed that this repository uses a [npm package called `json`](https://www.npmjs.com/package/json).

It is not used in any file nor any test. It might have been used previously in the package.json but it is not anymore. 

The library acts like a `jq` CLI. 

If you do not agree #114 should be re-opened and merged. 