### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Here is the [CSS customization](https://github.com/meilisearch/vuepress-plugin-m
 
 ## Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## Development Workflow and Contributing
 


### PR DESCRIPTION
- [x] Update README
- [x] Use the new version of `meilisearch-js` as a dependency (https://github.com/meilisearch/meilisearch-js/pull/667 should be merged before) #161 

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.