### PR TITLE
Add template customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The default behavior of this library fits perfectly for a documentation search b
 
 - [Optional parameters](#optional-parameters-) (when calling `docsSearchBar` method)
 - [Styling](#styling-) (with CSS)
+- [Templating](#templating-)
 
 #### Optional parameters <!-- omit in toc -->
 
@@ -162,6 +163,34 @@ For example, you might want to increase the number of results displayed in the d
 docsSearchBar({
   meilisearchOptions: {
     limit: 10,
+  },
+});
+```
+
+##### `Templating` <!-- omit in toc -->
+
+You can override the default mustache templates used by DocsSearch as long as they are formatted with mustache. To see all available templates that can be overridden go to [src/lib/templates.js](src/lib/templates.js).
+
+```javascript
+const mySuggestionTemplate = `
+    <a class="${suggestionPrefix}
+      {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
+      {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
+      "
+      aria-label="Hello World!"
+      href="{{{url}}}"
+      >
+      <div class="${suggestionPrefix}--category-header">
+          <span class="${suggestionPrefix}--category-header-lvl0">{{{category}}}</span>
+      </div>
+    </a>
+    `,
+
+docsSearchBar({
+  autocompleteOptions: {
+    templates: {
+      suggestion: mySuggestionTemplate,
+    },
   },
 });
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-commonjs */
 module.exports = {
   bail: true,
+  verbose: true,
   resetMocks: true,
   restoreMocks: true,
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/docs/'],

--- a/src/lib/DocsSearchBar.js
+++ b/src/lib/DocsSearchBar.js
@@ -56,7 +56,7 @@ class DocsSearchBar {
       enhancedSearchInput,
       layout,
     });
-    
+
     this.apiKey = apiKey;
     this.hostUrl = hostUrl;
     this.indexUid = indexUid;
@@ -75,7 +75,7 @@ class DocsSearchBar {
       autoselect: true,
       ...autocompleteOptions,
     };
-    this.templates = Templates(this.autocompleteOptions.templates || {})
+    this.templates = new Templates(this.autocompleteOptions.templates || {});
     const inputAriaLabel =
       this.input &&
       typeof this.input.attr === 'function' &&
@@ -107,7 +107,10 @@ class DocsSearchBar {
       {
         source: this.getAutocompleteSource(transformData, queryHook),
         templates: {
-          suggestion: DocsSearchBar.getSuggestionTemplate(this.isSimpleLayout, this.templates),
+          suggestion: DocsSearchBar.getSuggestionTemplate(
+            this.isSimpleLayout,
+            this.templates
+          ),
           footer: this.templates.footer,
           empty: DocsSearchBar.getEmptyTemplate(this.templates),
         },

--- a/src/lib/DocsSearchBar.js
+++ b/src/lib/DocsSearchBar.js
@@ -1,6 +1,6 @@
 import Hogan from 'hogan.js';
 import autocomplete from 'autocomplete.js';
-import templates from './templates';
+import Templates from './templates';
 import utils from './utils';
 import $ from './zepto';
 import MeiliSearch from 'meilisearch';
@@ -56,7 +56,7 @@ class DocsSearchBar {
       enhancedSearchInput,
       layout,
     });
-
+    
     this.apiKey = apiKey;
     this.hostUrl = hostUrl;
     this.indexUid = indexUid;
@@ -75,6 +75,7 @@ class DocsSearchBar {
       autoselect: true,
       ...autocompleteOptions,
     };
+    this.templates = Templates(this.autocompleteOptions.templates || {})
     const inputAriaLabel =
       this.input &&
       typeof this.input.attr === 'function' &&
@@ -99,16 +100,16 @@ class DocsSearchBar {
     });
 
     if (enhancedSearchInput) {
-      this.input = DocsSearchBar.injectSearchBox(this.input);
+      this.input = DocsSearchBar.injectSearchBox(this.input, this.templates);
     }
 
     this.autocomplete = autocomplete(this.input, this.autocompleteOptions, [
       {
         source: this.getAutocompleteSource(transformData, queryHook),
         templates: {
-          suggestion: DocsSearchBar.getSuggestionTemplate(this.isSimpleLayout),
-          footer: templates.footer,
-          empty: DocsSearchBar.getEmptyTemplate(),
+          suggestion: DocsSearchBar.getSuggestionTemplate(this.isSimpleLayout, this.templates),
+          footer: this.templates.footer,
+          empty: DocsSearchBar.getEmptyTemplate(this.templates),
         },
       },
     ]);
@@ -166,7 +167,7 @@ class DocsSearchBar {
     }
   }
 
-  static injectSearchBox(input) {
+  static injectSearchBox(input, templates) {
     input.before(templates.searchBox);
     const newInput = input.prev().prev().find('input');
     input.remove();
@@ -326,11 +327,11 @@ class DocsSearchBar {
     return null;
   }
 
-  static getEmptyTemplate() {
+  static getEmptyTemplate(templates) {
     return (args) => Hogan.compile(templates.empty).render(args);
   }
 
-  static getSuggestionTemplate(isSimpleLayout) {
+  static getSuggestionTemplate(isSimpleLayout, templates) {
     const stringTemplate = isSimpleLayout
       ? templates.suggestionSimple
       : templates.suggestion;

--- a/src/lib/__tests__/DocsSearchBar-test.js
+++ b/src/lib/__tests__/DocsSearchBar-test.js
@@ -3,6 +3,8 @@
 import sinon from 'sinon';
 import $ from '../zepto';
 import DocsSearchBar from '../DocsSearchBar';
+import Templates from '../templates';
+
 /**
  * Pitfalls:
  * Whenever you call new DocsSearchBar(), it will add the a new dropdown markup to
@@ -1084,10 +1086,10 @@ describe('DocsSearchBar', () => {
   });
 
   describe('getSuggestionTemplate', () => {
+    let templates;
     beforeEach(() => {
-      const templates = {
-        suggestion: '<div></div>',
-      };
+      templates =  new Templates({suggestion: "<div></div>"});
+      // console.log(templates.suggestion)
       DocsSearchBar.__Rewire__('templates', templates);
     });
     afterEach(() => {
@@ -1095,9 +1097,9 @@ describe('DocsSearchBar', () => {
     });
     it('should return a function', () => {
       // Given
-
+      
       // When
-      const actual = DocsSearchBar.getSuggestionTemplate();
+      const actual = DocsSearchBar.getSuggestionTemplate;
 
       // Then
       expect(actual).toBeInstanceOf(Function);
@@ -1116,7 +1118,7 @@ describe('DocsSearchBar', () => {
         // Given
 
         // When
-        DocsSearchBar.getSuggestionTemplate();
+        DocsSearchBar.getSuggestionTemplate(false, templates);
 
         // Then
         expect(Hogan.compile.calledOnce).toBe(true);
@@ -1124,7 +1126,7 @@ describe('DocsSearchBar', () => {
       });
       it('should call render on a Hogan template', () => {
         // Given
-        const actual = DocsSearchBar.getSuggestionTemplate();
+        const actual = DocsSearchBar.getSuggestionTemplate(false, templates);
 
         // When
         actual({ foo: 'bar' });

--- a/src/lib/__tests__/DocsSearchBar-test.js
+++ b/src/lib/__tests__/DocsSearchBar-test.js
@@ -1088,8 +1088,7 @@ describe('DocsSearchBar', () => {
   describe('getSuggestionTemplate', () => {
     let templates;
     beforeEach(() => {
-      templates =  new Templates({suggestion: "<div></div>"});
-      // console.log(templates.suggestion)
+      templates = new Templates({ suggestion: '<div></div>' });
       DocsSearchBar.__Rewire__('templates', templates);
     });
     afterEach(() => {
@@ -1097,7 +1096,7 @@ describe('DocsSearchBar', () => {
     });
     it('should return a function', () => {
       // Given
-      
+
       // When
       const actual = DocsSearchBar.getSuggestionTemplate;
 

--- a/src/lib/__tests__/DocsSearchBar-test.js
+++ b/src/lib/__tests__/DocsSearchBar-test.js
@@ -226,6 +226,41 @@ describe('DocsSearchBar', () => {
       expect(autocomplete.on.calledTwice).toBe(true);
       expect(autocomplete.on.calledWith('autocomplete:selected')).toBe(true);
     });
+
+    it('should be able to construct default templates when no user customizations are present', () => {
+      // Given
+
+      // When
+      const searchbar = new DocsSearchBar(defaultOptions);
+
+      // Then
+      expect(typeof searchbar.templates.suggestion).toBe('string');
+    });
+
+    it('should be able to construct templates from user customizations', () => {
+      // Given
+      const customizedTemplate = '<div></div>';
+
+      const options = {
+        ...defaultOptions,
+        autocompleteOptions: {
+          templates: {
+            suggestion: customizedTemplate,
+            suggestionSimple: customizedTemplate,
+            footer: customizedTemplate,
+            searchBox: customizedTemplate,
+          },
+        },
+      };
+      // When
+      const searchbar = new DocsSearchBar(options);
+
+      // Then
+      expect(searchbar.templates.suggestion).toBe(customizedTemplate);
+      expect(searchbar.templates.suggestionSimple).toBe(customizedTemplate);
+      expect(searchbar.templates.footer).toBe(customizedTemplate);
+      expect(searchbar.templates.searchBox).toBe(customizedTemplate);
+    });
   });
 
   describe('checkArguments', () => {

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -2,8 +2,22 @@ const prefix = 'docs-searchbar';
 const suggestionPrefix = `${prefix}-suggestion`;
 const footerPrefix = `${prefix}-footer`;
 
-function templates(options = {suggestion, suggestionSimple, footer, empty, searchBox}){
-  let defaults = {
+let suggestion;
+let suggestionSimple;
+let footer;
+let empty;
+let searchBox;
+
+function templates(
+  options = {
+    suggestion,
+    suggestionSimple,
+    footer,
+    empty,
+    searchBox,
+  }
+) {
+  const defaults = {
     suggestion: `
     <a class="${suggestionPrefix}
       {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -2,115 +2,118 @@ const prefix = 'docs-searchbar';
 const suggestionPrefix = `${prefix}-suggestion`;
 const footerPrefix = `${prefix}-footer`;
 
-const templates = {
-  suggestion: `
-  <a class="${suggestionPrefix}
-    {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
-    {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
-    "
-    aria-label="Link to the result"
-    href="{{{url}}}"
-    >
-    <div class="${suggestionPrefix}--category-header">
-        <span class="${suggestionPrefix}--category-header-lvl0">{{{category}}}</span>
-    </div>
-    <div class="${suggestionPrefix}--wrapper">
-      <div class="${suggestionPrefix}--subcategory-column">
-        <span class="${suggestionPrefix}--subcategory-column-text">{{{subcategory}}}</span>
+function templates(options = {suggestion, suggestionSimple, footer, empty, searchBox}){
+  let defaults = {
+    suggestion: `
+    <a class="${suggestionPrefix}
+      {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
+      {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
+      "
+      aria-label="Link to the result"
+      href="{{{url}}}"
+      >
+      <div class="${suggestionPrefix}--category-header">
+          <span class="${suggestionPrefix}--category-header-lvl0">{{{category}}}</span>
       </div>
-      {{#isTextOrSubcategoryNonEmpty}}
-      <div class="${suggestionPrefix}--content">
-        <div class="${suggestionPrefix}--subcategory-inline">{{{subcategory}}}</div>
-        <div class="${suggestionPrefix}--title">{{{title}}}</div>
-        {{#text}}<div class="${suggestionPrefix}--text">{{{text}}}</div>{{/text}}
+      <div class="${suggestionPrefix}--wrapper">
+        <div class="${suggestionPrefix}--subcategory-column">
+          <span class="${suggestionPrefix}--subcategory-column-text">{{{subcategory}}}</span>
+        </div>
+        {{#isTextOrSubcategoryNonEmpty}}
+        <div class="${suggestionPrefix}--content">
+          <div class="${suggestionPrefix}--subcategory-inline">{{{subcategory}}}</div>
+          <div class="${suggestionPrefix}--title">{{{title}}}</div>
+          {{#text}}<div class="${suggestionPrefix}--text">{{{text}}}</div>{{/text}}
+        </div>
+        {{/isTextOrSubcategoryNonEmpty}}
       </div>
-      {{/isTextOrSubcategoryNonEmpty}}
-    </div>
-  </a>
-  `,
-  suggestionSimple: `
-  <div class="${suggestionPrefix}
-    {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
-    {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
-    suggestion-layout-simple
-  ">
-    <div class="${suggestionPrefix}--category-header">
-        {{^isLvl0}}
-        <span class="${suggestionPrefix}--category-header-lvl0 ${suggestionPrefix}--category-header-item">{{{category}}}</span>
-          {{^isLvl1}}
-          {{^isLvl1EmptyOrDuplicate}}
-          <span class="${suggestionPrefix}--category-header-lvl1 ${suggestionPrefix}--category-header-item">
-              {{{subcategory}}}
-          </span>
-          {{/isLvl1EmptyOrDuplicate}}
-          {{/isLvl1}}
-        {{/isLvl0}}
-        <div class="${suggestionPrefix}--title ${suggestionPrefix}--category-header-item">
-            {{#isLvl2}}
-                {{{title}}}
-            {{/isLvl2}}
-            {{#isLvl1}}
+    </a>
+    `,
+    suggestionSimple: `
+    <div class="${suggestionPrefix}
+      {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
+      {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
+      suggestion-layout-simple
+    ">
+      <div class="${suggestionPrefix}--category-header">
+          {{^isLvl0}}
+          <span class="${suggestionPrefix}--category-header-lvl0 ${suggestionPrefix}--category-header-item">{{{category}}}</span>
+            {{^isLvl1}}
+            {{^isLvl1EmptyOrDuplicate}}
+            <span class="${suggestionPrefix}--category-header-lvl1 ${suggestionPrefix}--category-header-item">
                 {{{subcategory}}}
+            </span>
+            {{/isLvl1EmptyOrDuplicate}}
             {{/isLvl1}}
-            {{#isLvl0}}
-                {{{category}}}
-            {{/isLvl0}}
-        </div>
-    </div>
-    <div class="${suggestionPrefix}--wrapper">
-      {{#text}}
-      <div class="${suggestionPrefix}--content">
-        <div class="${suggestionPrefix}--text">{{{text}}}</div>
+          {{/isLvl0}}
+          <div class="${suggestionPrefix}--title ${suggestionPrefix}--category-header-item">
+              {{#isLvl2}}
+                  {{{title}}}
+              {{/isLvl2}}
+              {{#isLvl1}}
+                  {{{subcategory}}}
+              {{/isLvl1}}
+              {{#isLvl0}}
+                  {{{category}}}
+              {{/isLvl0}}
+          </div>
       </div>
-      {{/text}}
-    </div>
-  </div>
-  `,
-  footer: `
-    <div class="${footerPrefix}">
-      Powered by
-      <a href="https://www.meilisearch.com" target="_blank">
-        <img src="https://res.cloudinary.com/meilisearch/image/upload/v1582710599/Logo_fumols.svg" height="20" width="97" class="${footerPrefix}-logo"/>
-       </a>
-    </div>
-  `,
-  empty: `
-  <div class="${suggestionPrefix}">
-    <div class="${suggestionPrefix}--wrapper">
-        <div class="${suggestionPrefix}--content ${suggestionPrefix}--no-results">
-            <div class="${suggestionPrefix}--title">
-                <div class="${suggestionPrefix}--text">
-                    No results found for query <b>"{{query}}"</b>
-                </div>
-            </div>
+      <div class="${suggestionPrefix}--wrapper">
+        {{#text}}
+        <div class="${suggestionPrefix}--content">
+          <div class="${suggestionPrefix}--text">{{{text}}}</div>
         </div>
+        {{/text}}
+      </div>
     </div>
+    `,
+    footer: `
+      <div class="${footerPrefix}">
+        Powered by
+        <a href="https://www.meilisearch.com" target="_blank">
+          <img src="https://res.cloudinary.com/meilisearch/image/upload/v1582710599/Logo_fumols.svg" height="20" width="97" class="${footerPrefix}-logo"/>
+         </a>
+      </div>
+    `,
+    empty: `
+    <div class="${suggestionPrefix}">
+      <div class="${suggestionPrefix}--wrapper">
+          <div class="${suggestionPrefix}--content ${suggestionPrefix}--no-results">
+              <div class="${suggestionPrefix}--title">
+                  <div class="${suggestionPrefix}--text">
+                      No results found for query <b>"{{query}}"</b>
+                  </div>
+              </div>
+          </div>
+      </div>
+    </div>
+    `,
+    searchBox: `
+    <form novalidate="novalidate" onsubmit="return false;" class="searchbox">
+      <div role="search" class="searchbox__wrapper">
+        <input id="${suggestionPrefix}" type="search" name="search" placeholder="Search the docs" autocomplete="off" required="required" class="searchbox__input"/>
+        <button type="submit" title="Submit your search query." class="searchbox__submit" >
+          <svg width=12 height=12 role="img" aria-label="Search">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sbx-icon-search-13"></use>
+          </svg>
+        </button>
+        <button type="reset" title="Clear the search query." class="searchbox__reset hide">
+          <svg width=12 height=12 role="img" aria-label="Reset">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sbx-icon-clear-3"></use>
+          </svg>
+        </button>
+      </div>
+  </form>
+  
+  <div class="svg-icons" style="height: 0; width: 0; position: absolute; visibility: hidden">
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <symbol id="sbx-icon-clear-3" viewBox="0 0 40 40"><path d="M16.228 20L1.886 5.657 0 3.772 3.772 0l1.885 1.886L20 16.228 34.343 1.886 36.228 0 40 3.772l-1.886 1.885L23.772 20l14.342 14.343L40 36.228 36.228 40l-1.885-1.886L20 23.772 5.657 38.114 3.772 40 0 36.228l1.886-1.885L16.228 20z" fill-rule="evenodd"></symbol>
+      <symbol id="sbx-icon-search-13" viewBox="0 0 40 40"><path d="M26.806 29.012a16.312 16.312 0 0 1-10.427 3.746C7.332 32.758 0 25.425 0 16.378 0 7.334 7.333 0 16.38 0c9.045 0 16.378 7.333 16.378 16.38 0 3.96-1.406 7.593-3.746 10.426L39.547 37.34c.607.608.61 1.59-.004 2.203a1.56 1.56 0 0 1-2.202.004L26.807 29.012zm-10.427.627c7.322 0 13.26-5.938 13.26-13.26 0-7.324-5.938-13.26-13.26-13.26-7.324 0-13.26 5.936-13.26 13.26 0 7.322 5.936 13.26 13.26 13.26z" fill-rule="evenodd"></symbol>
+    </svg>
   </div>
-  `,
-  searchBox: `
-  <form novalidate="novalidate" onsubmit="return false;" class="searchbox">
-    <div role="search" class="searchbox__wrapper">
-      <input id="${suggestionPrefix}" type="search" name="search" placeholder="Search the docs" autocomplete="off" required="required" class="searchbox__input"/>
-      <button type="submit" title="Submit your search query." class="searchbox__submit" >
-        <svg width=12 height=12 role="img" aria-label="Search">
-          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sbx-icon-search-13"></use>
-        </svg>
-      </button>
-      <button type="reset" title="Clear the search query." class="searchbox__reset hide">
-        <svg width=12 height=12 role="img" aria-label="Reset">
-          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sbx-icon-clear-3"></use>
-        </svg>
-      </button>
-    </div>
-</form>
-
-<div class="svg-icons" style="height: 0; width: 0; position: absolute; visibility: hidden">
-  <svg xmlns="http://www.w3.org/2000/svg">
-    <symbol id="sbx-icon-clear-3" viewBox="0 0 40 40"><path d="M16.228 20L1.886 5.657 0 3.772 3.772 0l1.885 1.886L20 16.228 34.343 1.886 36.228 0 40 3.772l-1.886 1.885L23.772 20l14.342 14.343L40 36.228 36.228 40l-1.885-1.886L20 23.772 5.657 38.114 3.772 40 0 36.228l1.886-1.885L16.228 20z" fill-rule="evenodd"></symbol>
-    <symbol id="sbx-icon-search-13" viewBox="0 0 40 40"><path d="M26.806 29.012a16.312 16.312 0 0 1-10.427 3.746C7.332 32.758 0 25.425 0 16.378 0 7.334 7.333 0 16.38 0c9.045 0 16.378 7.333 16.378 16.38 0 3.96-1.406 7.593-3.746 10.426L39.547 37.34c.607.608.61 1.59-.004 2.203a1.56 1.56 0 0 1-2.202.004L26.807 29.012zm-10.427.627c7.322 0 13.26-5.938 13.26-13.26 0-7.324-5.938-13.26-13.26-13.26-7.324 0-13.26 5.936-13.26 13.26 0 7.322 5.936 13.26 13.26 13.26z" fill-rule="evenodd"></symbol>
-  </svg>
-</div>
-  `,
-};
+    `,
+  };
+  return Object.assign({}, defaults, options);
+}
 
 export default templates;


### PR DESCRIPTION
This will allow users the ability to customize templates through the
`autocompleteOptions`.

This is a feature that was requested by a user since before this was
forked from the docsearch and I kinda needed it so I thought I might
as well submit it as a PR :)

See-also: https://github.com/algolia/docsearch/issues/176