### PR TITLE
Fix input not linked to its style

### DIFF
--- a/scripts/playground.html
+++ b/scripts/playground.html
@@ -12,7 +12,7 @@
         <h1>Assets are served from http://127.0.0.1:8080/ </h1>
       </div>
       <div class="col-md-12">
-        <div class="input-group">
+        <div class="searchbox">
           <input type="search" placeholder="docs-searchbar input" class="form-control" id="q">
         </div>
       </div>
@@ -41,10 +41,18 @@
         margin: 10%;
       }
 
-      .input-group {
+      .searchbox {
         width: 60%;
         margin: auto;
         margin-top: 10%;
+        display: block;
+      }
+
+      .searchbox input {
+        height: 34px;
+        border-radius:4px;
+        font-size:14px;
+        padding: 6px 12px;
       }
     </style>
   </body>

--- a/src/styles/_searchbox.scss
+++ b/src/styles/_searchbox.scss
@@ -59,7 +59,7 @@
       position: relative;
     }
 
-    &__input {
+    input {
       display: inline-block;
       box-sizing: border-box;
       transition: box-shadow 0.4s ease, background 0.4s ease;


### PR DESCRIPTION
## What's wrong ?

Changing the style of the `searchbox` don't have any impact on it.

## Origin of the bug

Class names mismatch : 
- Class above the input component was called `input-group` ([here](https://github.com/meilisearch/docs-searchbar.js/blob/main/scripts/playground.html#L15))
- Class in style was called `searchbox` ([here](https://github.com/meilisearch/docs-searchbar.js/blob/main/src/styles/_searchbox.scss#L40))

## Resolution of the bug

I renamed the class name inside the `playground.html` into `searchbox`.

**Other changes :** 

The renaming of the class changed a little bit the style, as some styles inside the `.searchbox` were initially not taken in account but now are.
I made a few style changes in order to be compliant with the previous style.
This should only affect the playground but please make sure to double check in case I did something wrong 🙏

## How to test

Go to the `_variables.scss` and edit the style of the `$searchbox-config` ([here](https://github.com/meilisearch/docs-searchbar.js/blob/main/src/styles/_variables.scss#L2)). For example, you can edit the `input-background` and set it to red (`#F00`). 
On the `main` branch, this should have 0 incidence.
On this branch, you should see your changes being applied.