### PR TITLE
Add dark mode

### DIFF
--- a/scripts/playground.html
+++ b/scripts/playground.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="dark light" />
     <title>Docs SearchBar playground</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/bootstrap/3.3.6/css/bootstrap.min.css" />
     <link rel="stylesheet" href="http://127.0.0.1:8080/docs-searchbar.min.css" />
@@ -50,11 +51,17 @@
 
       .searchbox input {
         height: 34px;
-        border-radius:4px;
-        font-size:14px;
+        border-radius: 4px;
+        font-size: 14px;
         padding: 6px 12px;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #152028;
+          color: #eaeaea;
+        }
       }
     </style>
   </body>
-
 </html>

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -107,7 +107,9 @@
   $highlight-opacity: 0.1,
   $highlight-type: 'underline',
   $code-background: #ebebeb,
-  $responsive-breakpoint: 768px
+  $responsive-breakpoint: 768px,
+  $suggestion-background-color: #f8f8f8,
+  $hover-color-opacity: 0.05
 ) {
   $header-size: 1em;
   $title-size: 0.9em;
@@ -186,12 +188,12 @@
 
         &.dsb-cursor {
           .docs-searchbar-suggestion.suggestion-layout-simple {
-            background-color: rgba($main-color, 0.05);
+            background-color: rgba($main-color, $hover-color-opacity);
           }
 
           .docs-searchbar-suggestion:not(.suggestion-layout-simple) {
             .docs-searchbar-suggestion--content {
-              background-color: rgba($main-color, 0.05);
+              background-color: rgba($main-color, $hover-color-opacity);
             }
           }
         }
@@ -231,6 +233,9 @@
           color: set-highlight($highlight-opacity, $main-color);
           background: rgba(mix($main-color, #fff, 60%), $highlight-opacity);
           padding: 0em 0.05em;
+          @media (prefers-color-scheme: dark) {
+            color: lighten($main-color, 20%);
+          }
         }
 
         &--category-header
@@ -281,6 +286,9 @@
         padding: $padding/4 0;
         font-size: $header-size;
         color: $header-color;
+        @media (prefers-color-scheme: dark) {
+          color: lighten($subtitle-color, 10%);
+        }
       }
 
       &--wrapper {
@@ -409,6 +417,9 @@
         border-bottom: solid 1px #eee;
         padding: $padding/2;
         margin: 0;
+        @media (prefers-color-scheme: dark) {
+          border-bottom: solid 1px lighten($border-color, 10%);
+        }
       }
 
       .docs-searchbar-suggestion {
@@ -428,21 +439,25 @@
           width: 100%;
           border: none;
 
-          &-lvl0 {
+          &-lvl0, &-lvl1 {
             opacity: 0.6;
             font-size: $text-size;
+            @media (prefers-color-scheme: dark) {
+              opacity: unset;
+              color: lighten($subtitle-color, 10%);
+            }
           }
 
           &-lvl1 {
-            opacity: 0.6;
-            font-size: $text-size;
-
             &::before {
               background-image: url('data:image/svg+xml;utf8,<svg width="10" height="10" viewBox="0 0 20 38" xmlns="http://www.w3.org/2000/svg"><path d="M1.49 4.31l14 16.126.002-2.624-14 16.074-1.314 1.51 3.017 2.626 1.313-1.508 14-16.075 1.142-1.313-1.14-1.313-14-16.125L3.2.18.18 2.8l1.31 1.51z" fill-rule="evenodd" fill="%231D3657" /></svg>');
               content: '';
               width: 10px;
               height: 10px;
               display: inline-block;
+              @media (prefers-color-scheme: dark) {
+                filter: invert(1);
+              }
             }
           }
         }
@@ -464,12 +479,18 @@
           color: $main-color;
           font-size: $title-size;
           font-weight: normal;
+          @media (prefers-color-scheme: dark) {
+            color: $text-color;
+          }
 
           &::before {
             content: '#';
             font-weight: bold;
             color: $main-color;
             display: inline-block;
+            @media (prefers-color-scheme: dark) {
+              color: $text-color;
+            }
           }
         }
 
@@ -478,7 +499,7 @@
           display: desc($include-desc);
           line-height: 1.4em;
           padding: $padding/3 $padding/2;
-          background: #f8f8f8;
+          background: $suggestion-background-color;
           font-size: $text-size;
           opacity: 0.8;
 
@@ -486,6 +507,9 @@
             color: darken($text-color, 15%);
             font-weight: bold;
             box-shadow: none;
+            @media (prefers-color-scheme: dark) {
+              color: lighten($text-color, 15%);
+            }
           }
         }
       }
@@ -498,10 +522,14 @@
       z-index: 2000;
       margin-top: $padding/1.5;
       float: right;
+      color: $text-color;
     }
 
     .docs-searchbar-footer-logo {
       margin-bottom: 4px;
+      @media (prefers-color-scheme: dark) {
+        filter: invert(1);
+      }
     }
   }
 }

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -384,11 +384,14 @@
           text-align: left;
           float: left;
           padding: 0;
-
-          color: #02060c;
           font-size: 0.9em;
           font-weight: bold;
           opacity: 0.5;
+          color: #02060c;
+          @media (prefers-color-scheme: dark) {
+            color: $subtitle-color;
+            opacity: unset;
+          }
 
           &:before {
             display: none;

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -439,7 +439,8 @@
           width: 100%;
           border: none;
 
-          &-lvl0, &-lvl1 {
+          &-lvl0,
+          &-lvl1 {
             opacity: 0.6;
             font-size: $text-size;
             @media (prefers-color-scheme: dark) {

--- a/src/styles/_searchbox.scss
+++ b/src/styles/_searchbox.scss
@@ -22,6 +22,7 @@
   $input-width: 350px,
   $input-height: $font-size * 2.4,
   $border-width: 1px,
+  $text-color: #555,
   $border-radius: $input-height / 2,
   $input-border-color: #ccc,
   $input-focus-border-color: #1ec9ea,
@@ -60,6 +61,7 @@
     }
 
     input {
+      color: $text-color;
       display: inline-block;
       box-sizing: border-box;
       transition: box-shadow 0.4s ease, background 0.4s ease;
@@ -95,6 +97,9 @@
 
       &:hover {
         box-shadow: inset 0 0 0 $border-width darken($input-border-color, 10%);
+        @media (prefers-color-scheme: dark) {
+          box-shadow: inset 0 0 0 $border-width lighten($input-border-color, 5%);
+        }
       }
 
       &:focus,

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -4,18 +4,30 @@ $searchbox-config: (
   input-height: 32px,
   border-width: 1px,
   border-radius: 16px,
-  input-border-color: #cccccc,
-  input-focus-border-color: #aaaaaa,
-  input-background: #ffffff,
-  input-focus-background: #ffffff,
+  text-color: #555,
+  input-border-color: #ccc,
+  input-focus-border-color: #aaa,
+  input-background: #fff,
+  input-focus-background: #fff,
   font-size: 12px,
-  placeholder-color: #aaaaaa,
+  placeholder-color: #aaa,
   icon-size: 14px,
   icon-position: left,
   icon-color: #6d7e96,
   icon-background: #458ee1,
   icon-background-opacity: 0,
   icon-clear-size: 8px,
+) !default;
+
+$searchbox-config-dark: (
+  input-border-color: #686d71,
+  input-focus-border-color: #919598,
+  input-background: #444d52,
+  input-focus-background: #444d52,
+  placeholder-color: #bbbbbb,
+  text-color: #eaeaea,
+  icon-color: #6d7e96,
+  icon-background: #458ee1,
 ) !default;
 
 // DROPDOWN
@@ -32,7 +44,7 @@ $dropdown-config: (
   branding-position: bottom,
   spacing: normal,
   include-desc: yes,
-  background-category-header: #ffffff,
+  background-category-header: #fff,
   font-size: normal,
   header-color: #33363d,
   title-color: #02060c,
@@ -41,6 +53,23 @@ $dropdown-config: (
   highlight-color: #3881ff,
   highlight-opacity: 0.1,
   highlight-type: underline,
+  suggestion-background-color: #f8f8f8,
+  hover-color-opacity: 0.05,
+) !default;
+
+// Dropdown dark mode
+$dropdown-config-dark: (
+  background-color: #2c363e,
+  title-color: #eaeaea,
+  text-color: #eaeaea,
+  subtitle-color: #bbbbbb,
+  header-color: #7db0ea,
+  main-color: #458ee1,
+  background-category-header: #eaeaea,
+  border-color: #5b6369,
+  highlight-color: #3881ff,
+  suggestion-background-color: #6b7278,
+  hover-color-opacity: 0.5,
 ) !default;
 
 $builder-height: 260px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -6,6 +6,12 @@ $searchbox: true !default;
 
 @if ($searchbox == true) {
   @include searchbox($searchbox-config...);
+  @media (prefers-color-scheme: dark) {
+    @include searchbox($searchbox-config-dark...);
+  }
 }
 
 @include dropdown($dropdown-config...);
+@media (prefers-color-scheme: dark) {
+  @include dropdown($dropdown-config-dark...);
+}


### PR DESCRIPTION
## What's wrong ? 

By switching to dark mode, there is no impact on the style.

## What's inside this PR

Addition of new variables `searchbox-config-dark` and `dropdown-config-dark` which contains overrides of the colors in light mode. 
Addition of `@media (prefers-color-scheme: dark)` media query when needed in the code.
Note that I am not a designer, so the choosen color and style are purely subjective.

## How to test

Go to the project and `yarn && yarn serve`

Go to `System Preferences` in your mac, then `General`, and switch to dark mode.
Please make sure to test that it doesn't break the light mode, both in "simple" and "columns" layout.

To switch to "simple" layout, add `layout: "simple"` to your `scripts/playground.html`: 

![Capture d’écran 2021-06-02 à 09 48 06](https://user-images.githubusercontent.com/30866152/120444202-b20b0500-c387-11eb-99bf-1ce64c8f02c3.png)


## Result

Before ("simple" layout):

![before simple](https://user-images.githubusercontent.com/30866152/120443859-593b6c80-c387-11eb-8b6e-cee5dbb99618.png)

After ("simple" layout):

![dark mode simple](https://user-images.githubusercontent.com/30866152/120443868-5c365d00-c387-11eb-84c9-ac9af3cc6c39.png)

Before / after: 

https://user-images.githubusercontent.com/30866152/120444366-d9fa6880-c387-11eb-87c2-3d456492660f.mov



Before ("columns" layout):

![before columns](https://user-images.githubusercontent.com/30866152/120443901-66585b80-c387-11eb-9e09-02a5741464e2.png)

After ("columns" layout):

![dark mode columns](https://user-images.githubusercontent.com/30866152/120443917-69534c00-c387-11eb-982d-89f1cbe291ed.png)

Before / after: 

https://user-images.githubusercontent.com/30866152/120444437-e8488480-c387-11eb-8e3c-716b12cf3ad1.mov

