### PR TITLE
Add automatic minor increase on feature

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -6,10 +6,15 @@ version-resolver:
   major:
     labels:
       - 'breaking-change'
+  minor:
+    labels:
+      - 'feature'
   default: patch
 categories:
   - title: 'Breaking changes ⚠️'
     label: 'breaking-change'
+  - title: 'New features ⚡️'
+    label: 'feature'
 template: |
   ## Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,6 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 This project integrates a tool to create automated changelogs.<br>
 _[Read more about this](https://github.com/meilisearch/integration-guides/blob/main/guides/release-drafter.md)._
 
-### Labels
-
-To chose the proper labels reade the [labels guide](https://github.com/meilisearch/integration-guides/blob/main/guides/release-drafter.md#how-does-the-release-drafter-work)). Labels impact the generated version for the next release.
-
 ### How to Publish the Release <!-- omit in TOC -->
 
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/guides/integration-release.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,10 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 This project integrates a tool to create automated changelogs.<br>
 _[Read more about this](https://github.com/meilisearch/integration-guides/blob/main/guides/release-drafter.md)._
 
+### Labels
+
+To chose the proper labels reade the [labels guide](https://github.com/meilisearch/integration-guides/blob/main/guides/release-drafter.md#how-does-the-release-drafter-work)). Labels impact the generated version for the next release.
+
 ### How to Publish the Release <!-- omit in TOC -->
 
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/guides/integration-release.md).


### PR DESCRIPTION
When a new feature is added to a project that already has a fist major version, the update of the semver goes the following way: 

> MAJOR version when you make incompatible API changes,
MINOR version when you add functionality in a backwards compatible manner, and
PATCH version when you make backwards compatible bug fixes.

This does not apply on packages with no major version. 

To avoid having to manually update the minor version on new features, this PR adds the automation of the minor increase when using the `new-feature` label. 

## Naming of the label

### feature 👍

The name `feature` is based on the following common practices: 
[GitHub Labels that are logical, colorful and sensible](https://docs.saltproject.io/en/latest/topics/development/labels.html#labels)
[GitLab suggested labels](https://docs.gitlab.com/ee/user/project/labels.html)
> Categorize epics, issues, and merge requests using colors and descriptive titles like bug, feature request, or docs.

Take into account that these are two suggested naming. A lot of other articles exists with different suggestion and the first article also invites to use `type:` in front of the label.

### new-feature 🎉
Another possibility would be to use `new-feature` as it is more explicit linked to a PR and not an issue.

I suggest `new-feature` instead of `new feature` for consistency with `breaking-changes` and `skip-changelog`


If you prefer `feature` 👍
If you prefer `new-feature` 🎉


⚠️ Wait for [this pr](https://github.com/meilisearch/integration-guides/pull/129) before merging

