### PR TITLE
Remove jest from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - dependency-name: "*eslint*"
       - dependency-name: "babel-eslint"
       - dependency-name: "*prettier*"
+      - dependency-name: "*jest*"
+      - dependency-name: "pretty-bytes-cli"
 - package-ecosystem: npm
   directory: "/playground/javascript"
   schedule:


### PR DESCRIPTION
`Jest` is a testing library that does not impact our package users
`pretty-bytes-cli` is a library that improves logging visual.