### PR TITLE
Update version for the next release (v2.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-searchbar.js",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "Add a relevant search bar to your documentation using MeiliSearch",
   "keywords": [
     "documentation",


### PR DESCRIPTION
Update to v2 because of a deprecation with node-saas. Users using docs-searchbar will have to migrate to dart-saas. 

https://github.com/meilisearch/docs-searchbar.js/pull/447