### PR TITLE
Fix footer meilisearch position

### DIFF
--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -519,7 +519,8 @@
 
     // powered by
     .docs-searchbar-footer {
-      width: 180px;
+      width: 100%;
+      text-align: right;
       height: 20px;
       z-index: 2000;
       margin-top: math.div($padding, 1.5);


### PR DESCRIPTION
# Pull Request

## What does this PR do?

MeiliSearch logo disappears because size of footer is to small to hold both text and image
<img width="503" alt="Screenshot 2021-11-12 at 18 31 52" src="https://user-images.githubusercontent.com/33010418/141509793-05eceda6-050e-40b8-956f-1f6434287969.png">

This PR uses `text-align: right` and `width:100%` to ensure that the footer can use all the available space to render and still show up to the right of the search screen
<img width="507" alt="Screenshot 2021-11-12 at 18 34 27" src="https://user-images.githubusercontent.com/33010418/141510088-1e63e15c-5970-4e45-ae05-556d234c23e6.png">

(don't take care of the grey, its because it was selected)