### PR TITLE
Update enableDarkMode to auto in playground

### DIFF
--- a/playgrounds/html/index.html
+++ b/playgrounds/html/index.html
@@ -34,7 +34,7 @@
       },
       debug: true, // Set debug to true if you want to inspect the dropdown
       enhancedSearchInput: true,
-      enableDarkMode: true
+      enableDarkMode: 'auto'
     })
   </script>
   <style>


### PR DESCRIPTION
## Problem

`enableDarkMode` is still in `true`, causing the dark mode to be displayed even if the system is in light mode.

## Solution

Set `enableDarkMode` to `auto` to let the system decide which theme to display