### PR TITLE
Update meilisearch-js to v0.27.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "autocomplete.js": "^0.38.1",
-    "meilisearch": "^0.25.1",
+    "meilisearch": "^0.27.0-beta.1",
     "to-factory": "^1.0.0",
     "zepto": "^1.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5515,10 +5515,10 @@ mdn-data@2.0.4:
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-meilisearch@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.25.1.tgz#0dc25ffad64e6e50eb3da6c0691b0ff54f8578bf"
-  integrity sha512-20jO0pK9BhghxHSkOLbdoYn58h/Z0PNL3JQcRq7ipNIeqrxkAetCZZ6ttJC3uxcz0jVglmiFoSXu3Z/lEOLOLQ==
+meilisearch@^0.27.0-beta.1:
+  version "0.27.0-beta.1"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0-beta.1.tgz#62e64da55227f405e3f352a43e470947ac50f5ef"
+  integrity sha512-AnUnYKjpghPVC3zBXbF7QeikADfLyHl37aIcLS5xj+zqzku3ldQlOb9AbyBZ1gDhhWxrbltEgb0btmGyBv2jyQ==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
Update meilisearch-js version to prepare docs-searchbar.js for the next release of meilisearch (v0.28.0)