### PR TITLE
Add CI to publish beta versions

### DIFF
--- a/.github/scripts/beta-docker-version.sh
+++ b/.github/scripts/beta-docker-version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+package_json_version=$(grep '"version":' package.json | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
+beta_feature=$(echo $package_json_version | sed -r 's/[0-9]+.[0-9]+.[0-9]+-//')
+beta_feature=$(echo $beta_feature | sed -r 's/-beta\.[0-9]*$//')
+
+docker_image=$(curl https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags | jq | grep "$beta_feature" | head -1)
+docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
+echo $docker_image

--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Checking if current tag matches the required formating
+is_pre_release=$1
+current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | tr -d ' ',v)
+
+if [ $is_pre_release = false ]; then
+  # Works with the format vX.X.X
+  #
+  # Example of correct format:
+  # v0.1.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
+  if [ $? != 0 ]; then
+    echo "Error: Your tag: $current_tag is wrongly formatted."
+    echo 'Please refer to the contributing guide for help.'
+    exit 1
+  fi
+  exit 0
+elif [ $is_pre_release = true ]; then
+  # Works with the format vX.X.X-xxx-beta.X
+  # none or multiple -xxx are valid
+  #
+  # Examples of correct format:
+  # v0.1.0-beta.0
+  # v0.1.0-xxx-beta.0
+  # v0.1.0-xxx-xxx-beta.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*-([a-z]*-)*beta\.[0-9]*$"
+
+  if [ $? != 0 ]; then
+    echo "Error: Your beta tag: $current_tag is wrongly formatted."
+    echo 'Please refer to the contributing guide for help.'
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 0

--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -1,0 +1,81 @@
+# Testing the code base against a specific Meilisearch feature
+name: Beta tests
+
+# Will only run for PRs and pushes to *-beta
+on:
+  push:
+    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+  pull_request:
+    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+
+jobs:
+  meilisearch-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.grep-step.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Grep docker beta version of Meilisearch
+        id: grep-step
+        run: |
+          MEILISEARCH_VERSION=$(sh .github/scripts/beta-docker-version.sh)
+          echo $MEILISEARCH_VERSION
+          echo ::set-output name=version::$MEILISEARCH_VERSION
+  cypress-run:
+    runs-on: ubuntu-latest
+    needs: ['meilisearch-version']
+    services:
+      meilisearch:
+        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
+        env:
+          MEILI_MASTER_KEY: 'masterKey'
+          MEILI_NO_ANALYTICS: 'true'
+        ports:
+          - '7700:7700'
+    name: end-to-end-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
+      - name: Install dependencies
+        run: yarn --dev && yarn --cwd ./tests/env/browser
+      - name: Browser tests
+        uses: cypress-io/github-action@v3
+        with:
+          # Your starting script
+          start: yarn test:browser
+      # Creates and uploads GitHub artifacts in case of failure
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-videos
+          path: cypress/videos
+  integration_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['14', '16', '18']
+    name: integration-tests (Node.js ${{ matrix.node }})
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Build
+        run: yarn run build
+      - name: Run tests
+        run: yarn run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,17 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
           cache: 'yarn'
-      - name: Install dependencies
-        run: yarn install
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
-      - name: Build
-        run: NODE_ENV=production yarn run build
-      - name: Publish
-        run: npm publish
+      - name: Check tag format
+        run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
+      - name: Publish with latest tag
+        if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
+        run: npm publish .
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish with beta tag
+        if: "github.event.release.prerelease && contains(github.ref, 'beta')"
+        run: npm publish . --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,47 @@ Once the changes are merged on `main`, you can publish the current draft release
 
 GitHub Actions will be triggered and push the package to [npm](https://www.npmjs.com/package/docs-searchbar.js).
 
+#### Release a `beta` Version
+
+Here are the steps to release a beta version of this package:
+
+- Create a new branch containing the "beta" changes with the following format `xxx-beta` where `xxx` explains the context.
+
+  For example:
+    - When implementing a beta feature, create a branch `my-feature-beta` where you implement the feature.
+      ```bash
+        git checkout -b my-feature-beta
+      ```
+    - During the Meilisearch pre-release, create a branch originating from `bump-meilisearch-v*.*.*` named `meilisearch-v*.*.*-beta`. <br>
+    `v*.*.*` is the next version of the package, NOT the version of Meilisearch!
+
+      ```bash
+      git checkout bump-meilisearch-v*.*.*
+      git pull origin bump-meilisearch-v*.*.*
+      git checkout -b bump-meilisearch-v*.*.*-beta
+      ```
+
+- Change the version in [`package.json`](/package.json) and [`src/lib/version.js`](/src/lib/version.js) with `*.*.*-xxx-beta.0` and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
+  - `v*.*.*-my-feature-beta.0`
+  - `v*.*.*-beta.0`
+
+- Go to the [GitHub interface for releasing](https://github.com/meilisearch/docs-searchbar.js/releases): on this page, click on `Draft a new release`.
+
+- Create a GitHub pre-release:
+  - Fill the description with the detailed changelogs
+  - Fill the title with `vX.X.X-beta.0`
+  - Fill the tag with `vX.X.X-beta.0`
+  - ⚠️ Select the `vX.X.X-beta.0` branch and NOT `main`
+  - ⚠️ Click on the "This is a pre-release" checkbox
+  - Click on "Publish release"
+
+GitHub Actions will be triggered and push the beta version to [npm](https://www.npmjs.com/package/docs-searchbar.js).
+
+💡 If you need to release a new beta for the same version (i.e. `vX.X.X-beta.1`):
+- merge the change into your beta branch
+- change the version name in `package.json`
+- creata a pre-release via the GitHub interface
+
 <hr>
 
 Thank you again for reading this through, we can not wait to begin to work with you if you made your way through this contributing guide ❤️

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,9 +172,7 @@ Here are the steps to release a beta version of this package:
       git checkout -b bump-meilisearch-v*.*.*-beta
       ```
 
-- Change the version in [`package.json`](/package.json) and [`src/lib/version.js`](/src/lib/version.js) with `*.*.*-xxx-beta.0` and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
-  - `v*.*.*-my-feature-beta.0`
-  - `v*.*.*-beta.0`
+- Change the version in [`package.json`](/package.json) and [`src/lib/version.js`](/src/lib/version.js) with `*.*.*-xxx-beta.0` and commit it to the `beta` branch.
 
 - Go to the [GitHub interface for releasing](https://github.com/meilisearch/docs-searchbar.js/releases): on this page, click on `Draft a new release`.
 


### PR DESCRIPTION
In this PR: 

- Adds a specific Beta testing CI to ensure the tests passes on the specific docker image of Meilisearch containing the feature
- Adds a versions checker for the Beta
- Adds a publish condition to publish with the beta tag


fixes: #590 