### PR TITLE
Fix publish CI not building

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ jobs:
         run: sh .github/scripts/check-release.sh
       - name: Check tag format
         run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
+      - name: Install dependencies
+        run: yarn install
+      - name: Build
+        run: NODE_ENV=production yarn run build
       - name: Publish with latest tag
         if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
         run: npm publish .


### PR DESCRIPTION
In PR number https://github.com/meilisearch/docs-searchbar.js/pull/635 I accidentaly removed the build and install part in the publish CI.

Putting it back as it published to npm without source files.