### PR TITLE
Fix node version from 15 to 16 in pre-release tests CI

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '15', '18']
+        node: ['14', '16', '18']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Tested node version should have been, 14, 16 and 18 and not 15. 